### PR TITLE
mergine Root6 xaod_trig to xaod_trig

### DIFF
--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -69,9 +69,9 @@ XaodAnalysis::XaodAnalysis() :
     m_flagsAreConsistent(false),
     m_flagsHaveBeenChecked(false),
     //m_event(xAOD::TEvent::kClassAccess),
-    m_event(xAOD::TEvent::kBranchAccess),
+    m_event(xAOD::TEvent::kBranchAccess), ///> dantrim -- check what this does (in PAT threads, TDT is supposed to work with kBranchAccess option)
     m_store(),
-//	m_eleIDDefault(Medium), ///> not likelihood
+//	m_eleIDDefault(Medium), ///> dantrim -- use likelihood as default ?
         m_eleIDDefault(TightLLH),
 	m_electronEfficiencySFTool(0),
 	m_pileupReweightingTool(0),
@@ -236,22 +236,14 @@ XaodAnalysis& XaodAnalysis::initLocalTools()
     initMuonTools();
     initTauTools();
 
+    // dantrim -- initialize trigger tool
+    initTrigger();
 
-    // dantrim trig
-/*    m_configTool = new TrigConf::xAODConfigTool("TrigConf::xAODConfigTool");
-    ToolHandle<TrigConf::ITrigConfigTool> configHandle(m_configTool);
-    CHECK( configHandle->initialize() );
-    
-    m_trigTool = new Trig::TrigDecisionTool("TrigDecTool");
-    m_trigTool->setProperty("ConfigTool", configHandle);
-    m_trigTool->setProperty("TrigDecisionKey", "xTrigDecision");
-    CHECK( m_trigTool->initialize() );
-*/
-
+    // dantrim -- Call EventShapeCopier tool when accessing jets (cluster objects).
+    //            Call "renameEventDensities". This is temporary? And only for
+    //            DxAODs. If running over DxAOD be sure to put "derived" in the sample
+    //            name '-s' option (case insensitive).
     m_escopier = new EventShapeCopier("Kt4LCCopier");
-//    if ( m_isDerivation ) {
-//        m_escopier->renameEventDensities();
-//    }
 
 
     return *this;
@@ -299,6 +291,21 @@ void XaodAnalysis::initTauTools()
 
 }
 
+//----------------------------------------------------------
+void XaodAnalysis::initTrigger()
+{
+    // dantrim trig
+    m_configTool = new TrigConf::xAODConfigTool("xAODConfigTool");
+    ToolHandle<TrigConf::ITrigConfigTool> configHandle(m_configTool);
+    CHECK( configHandle->initialize() );
+    
+    m_trigTool = new Trig::TrigDecisionTool("TrigDecTool");
+    m_trigTool->setProperty("ConfigTool", configHandle);
+    m_trigTool->setProperty("TrigDecisionKey", "xTrigDecision");
+    m_trigTool->setProperty("OutputLevel", MSG::ERROR).ignore(); // dantrim Mar 16 2015 -- tool outputs extraneous errors due to extraneous tool, ignore them
+    CHECK( m_trigTool->initialize() );
+
+}
 
 /*--------------------------------------------------------------------------------*/
 // Get the list of recommended systematics from CP
@@ -404,9 +411,7 @@ xAOD::JetContainer* XaodAnalysis::xaodJets(ST::SystInfo sysInfo, SusyNtSys sys)
     if(sys!=NtSys::NOM && syst_affectsJets){
         if(m_xaodJets==NULL){
             // dantrim event shape
-            if ( m_isDerivation ) {
-                m_escopier->renameEventDensities();
-            }
+            if ( m_isDerivation ) m_escopier->renameEventDensities();
             m_susyObj[m_eleIDDefault]->GetJets(m_xaodJets, m_xaodJetsAux);
         }
         if(m_dbg>=5) cout << "xaodJets " << m_xaodJets->size() << endl;
@@ -415,9 +420,7 @@ xAOD::JetContainer* XaodAnalysis::xaodJets(ST::SystInfo sysInfo, SusyNtSys sys)
     else{
         if(m_xaodJets_nom==NULL){
             // dantrim event shape
-            if ( m_isDerivation ) {
-                m_escopier->renameEventDensities();
-            }
+            if ( m_isDerivation ) m_escopier->renameEventDensities();
             m_susyObj[m_eleIDDefault]->GetJets(m_xaodJets_nom, m_xaodJetsAux_nom);
         }
         if(m_dbg>=5) cout << "xaodJets_nom " << m_xaodJets_nom->size() << endl;
@@ -554,6 +557,14 @@ void XaodAnalysis::selectBaselineObjects(SusyNtSys sys, ST::SystInfo sysInfo)
     if(m_dbg>=5) cout << "selectBaselineObjects with sys=" <<  SusyNtSysNames[sys] << endl;
 
     xAOD::ElectronContainer* electrons = xaodElectrons(sysInfo,sys);
+    xAOD::MuonContainer* muons =xaodMuons(sysInfo,sys);
+    xAOD::JetContainer* jets = xaodJets(sysInfo,sys);
+
+    // dantrim March 17 1015 -- call initially in case we want to check OR on baseline.
+    //                          For now, have set "doHarmonization=False"
+    m_susyObj[m_eleIDDefault]->OverlapRemoval(electrons, muons, jets, false); 
+  //  m_susyObj[m_eleIDDefault]->OverlapRemoval(xaodElectrons(sysInfo,sys), xaodMuons(sysInfo, sys), xaodJets(sysInfo, sys), false);
+  //  xAOD::ElectronContainer* electrons = xaodElectrons(sysInfo,sys);
     int iEl = -1;
     for(const auto& el : *electrons) {
         iEl++;
@@ -564,9 +575,10 @@ void XaodAnalysis::selectBaselineObjects(SusyNtSys sys, ST::SystInfo sysInfo)
                          <<" eta " << el->eta()
                          <<" phi " << el->phi()
                          <<endl;
-        if(!el->auxdata< bool >("baseline")) continue;
+      //  if(!el->auxdata< bool >("baseline")) continue;
         //AT:12/16/14 TO UPDATE Base Obj should be after overlap removal
-        if( el->auxdata< bool >("baseline") ) m_baseElectrons.push_back(iEl);
+        if( el->auxdata< bool >("baseline") &&
+            el->auxdata< bool >("passOR") ) m_baseElectrons.push_back(iEl); 
 
         if(m_dbg>=5) cout<<"\t El passing"
                          <<" baseline? "<< bool(el->auxdata< bool >("baseline"))
@@ -577,7 +589,7 @@ void XaodAnalysis::selectBaselineObjects(SusyNtSys sys, ST::SystInfo sysInfo)
     if(m_dbg) cout<<"preElectrons["<<m_preElectrons.size()<<"]"<<endl;
 
     int iMu = -1;
-    xAOD::MuonContainer* muons =xaodMuons(sysInfo,sys);
+ //   xAOD::MuonContainer* muons =xaodMuons(sysInfo,sys);
     for(const auto& mu : *muons){
         iMu++;
         m_preMuons.push_back(iMu);
@@ -591,13 +603,14 @@ void XaodAnalysis::selectBaselineObjects(SusyNtSys sys, ST::SystInfo sysInfo)
                          <<" eta " << mu->eta()
                          <<" phi " << mu->phi()
                          <<endl;
-        if( mu->auxdata< bool >("baseline") ) m_baseMuons.push_back(iMu);
+        if( mu->auxdata< bool >("baseline") && 
+            mu->auxdata< bool >("passOR") ) m_baseMuons.push_back(iMu); 
         // if(signal) m_sigMuons.push_back(iMu);
     }
     if(m_dbg) cout<<"preMuons["<<m_preMuons.size()<<"]"<<endl;
 
     int iJet=-1;
-    xAOD::JetContainer* jets = xaodJets(sysInfo,sys);
+  //  xAOD::JetContainer* jets = xaodJets(sysInfo,sys);
     for(const auto& jet : *jets){
         iJet++;
         m_preJets.push_back(iJet);
@@ -609,14 +622,16 @@ void XaodAnalysis::selectBaselineObjects(SusyNtSys sys, ST::SystInfo sysInfo)
                          <<" eta " << jet->eta()
                          <<" phi " << jet->phi()
                          <<endl;
-        if(jet->auxdata< bool >("baseline")) m_baseJets.push_back(iJet);
+        if(jet->auxdata< bool >("baseline") &&
+           jet->auxdata< bool >("passOR") ) m_baseJets.push_back(iJet); 
     }
     if(m_dbg) cout<<"preJets["<<m_preJets.size()<<"]"<<endl;
 
     // overlap removal and met (need to build 'MyJet' coll?)
     //AT:: Depending of what container is affected by systematic, feed the correct set for the met computation
     // dantrim March 2 2015 -- setting "doHarmonization" to False, in accord with Ximo & Fabio
-    m_susyObj[m_eleIDDefault]->OverlapRemoval(xaodElectrons(sysInfo,sys), xaodMuons(sysInfo, sys), xaodJets(sysInfo, sys), false);
+    //m_susyObj[m_eleIDDefault]->OverlapRemoval(xaodElectrons(sysInfo,sys), xaodMuons(sysInfo, sys), xaodJets(sysInfo, sys), false);
+
 
     int iTau=-1;
     xAOD::TauJetContainer* taus = xaodTaus(sysInfo,sys);
@@ -1117,22 +1132,26 @@ bool XaodAnalysis::passGRL(const xAOD::EventInfo* eventinfo)
             m_grl->passRunLB(eventinfo->runNumber(), eventinfo->lumiBlock()));
 }
 //----------------------------------------------------------
-bool XaodAnalysis::passTTCVeto()
+bool XaodAnalysis::passTTCVeto(const xAOD::EventInfo* eventinfo)
 {
-    return true; // DG-2014-08-16 \todo
+    bool eventPassesTTC = eventinfo->isEventFlagBitSet(xAOD::EventInfo::Core, 18) ? false : true;
+    return eventPassesTTC;
     //   return (m_event.eventinfo.coreFlags() & 0x40000) == 0;
 }
 //----------------------------------------------------------
 bool XaodAnalysis::passTileErr(const xAOD::EventInfo* eventinfo)
 {
-	bool eventPassesTileTrip = (m_isMC ||
-                                true); // SUSYToolsTester: move to xAOD tool
+    // dantrim - add check of MC? >> seems to catch this, MC set to true
+    bool eventPassesTileTrip = eventinfo->errorState(xAOD::EventInfo::Tile)==xAOD::EventInfo::Error ? false : true;
+//	bool eventPassesTileTrip = (m_isMC || true); // SUSYToolsTester: move to xAOD tool
     return eventPassesTileTrip;
 }
 //----------------------------------------------------------
-bool XaodAnalysis::passLarErr()
+bool XaodAnalysis::passLarErr(const xAOD::EventInfo* eventinfo)
 {
-    return true; // DG-2014-08-16 \todo
+    // dantrim - add check of MC? >> seems to catch this, MC set to true
+    bool eventPassesLarErr = eventinfo->errorState(xAOD::EventInfo::LAr)==xAOD::EventInfo::Error ? false : true;
+    return eventPassesLarErr;
 //    return m_isMC || (m_event.eventinfo.larError()!=2);
 }
 /*--------------------------------------------------------------------------------*/
@@ -1141,22 +1160,22 @@ bool XaodAnalysis::passLarErr()
 void XaodAnalysis::assignEventCleaningFlags()
 {
     const xAOD::EventInfo* eventinfo = xaodEventInfo();
-    if(passGRL(eventinfo))      m_cutFlags |= ECut_GRL;
-    if(passTTCVeto())           m_cutFlags |= ECut_TTC;
-    if(passLarErr())            m_cutFlags |= ECut_LarErr;
-    if(passTileErr(eventinfo))  m_cutFlags |= ECut_TileErr;
-    if(passGoodVtx())           m_cutFlags |= ECut_GoodVtx;
-    if(passTileTrip())          m_cutFlags |= ECut_TileTrip;
+    if(passGRL(eventinfo))            m_cutFlags |= ECut_GRL;
+    if(passTTCVeto(eventinfo))        m_cutFlags |= ECut_TTC;
+    if(passLarErr(eventinfo))         m_cutFlags |= ECut_LarErr; 
+    if(passTileErr(eventinfo))        m_cutFlags |= ECut_TileErr;
+    if(passGoodVtx())                 m_cutFlags |= ECut_GoodVtx;
+    if(passTileTrip())                m_cutFlags |= ECut_TileTrip;
 }
 //----------------------------------------------------------
 void XaodAnalysis::assignObjectCleaningFlags(ST::SystInfo sysInfo, SusyNtSys sys)
 {
     //AT check if m_cutFalgs save at each systematics ?
-    if(passTileHotSpot()) m_cutFlags |= ECut_HotSpot;
-    if(passBadJet())      m_cutFlags |= ECut_BadJet;
-    if(passBadMuon(sysInfo,sys))     m_cutFlags |= ECut_BadMuon;
-    if(passCosmic(sysInfo,sys))      m_cutFlags |= ECut_Cosmic;
-    if(passLarHoleVeto()) m_cutFlags |= ECut_SmartVeto;
+    if(passTileHotSpot())             m_cutFlags |= ECut_HotSpot;
+    if(passBadJet(sysInfo, sys))      m_cutFlags |= ECut_BadJet;
+    if(passBadMuon(sysInfo,sys))      m_cutFlags |= ECut_BadMuon;
+    if(passCosmic(sysInfo,sys))       m_cutFlags |= ECut_Cosmic;
+    if(passLarHoleVeto())             m_cutFlags |= ECut_SmartVeto;
 }
 //----------------------------------------------------------
 bool XaodAnalysis::passLarHoleVeto()
@@ -1172,10 +1191,14 @@ bool XaodAnalysis::passTileHotSpot()
 //-DG--  return !check_jet_tileHotSpot(jets, m_preJets, m_susyObj, !m_isMC, m_event.eventinfo.RunNumber());
 }
 //----------------------------------------------------------
-bool XaodAnalysis::passBadJet()
+bool XaodAnalysis::passBadJet(ST::SystInfo sysInfo, SusyNtSys sys)
 {
-    //const xAOD::JetContainer *jets =  xaodJets();
-    return false;
+    xAOD::JetContainer* jets = xaodJets(sysInfo, sys);
+    bool pass_jetCleaning = true;
+    for(auto &i : m_preJets) { 
+        if(jets->at(i)->auxdata< bool >("bad")) pass_jetCleaning = false;
+    } 
+    return pass_jetCleaning;
 //  return !IsBadJetEvent(jets, m_baseJets, 20.*GeV, m_susyObj);
 }
 //----------------------------------------------------------
@@ -1202,27 +1225,33 @@ bool XaodAnalysis::passTileTrip()
 bool XaodAnalysis::passBadMuon(ST::SystInfo sysInfo, SusyNtSys sys)
 {
     xAOD::MuonContainer* muons = xaodMuons(sysInfo, sys);
-    for(auto it=muons->begin(), end=muons->end(); it!=end; ++it){
-        const xAOD::Muon &mu = **it;
-        //AT-2014-10-30  should be done only for preMuons ? any more cuts to applied ?
-        if(m_susyObj[m_eleIDDefault]->IsBadMuon(mu)) return false;
+    bool pass_bad_muon = true;
+    for(auto &i : m_baseMuons) {
+        if(m_susyObj[m_eleIDDefault]->IsBadMuon(*muons->at(i))) pass_bad_muon = false;
     }
-    return true;
+    return pass_bad_muon;
     //  return !IsBadMuonEvent(m_susyObj, xaodMuons(), m_preMuons, 0.2);
 }
 //----------------------------------------------------------
 bool XaodAnalysis::passCosmic(ST::SystInfo sysInfo, SusyNtSys sys)
 {
     xAOD::MuonContainer* muons = xaodMuons(sysInfo, sys);
-    for(auto it=muons->begin(), end=muons->end(); it!=end; ++it){
-        const xAOD::Muon &mu = **it;
-  //      if(!mu.auxdata< bool >("baseline")) continue; // dantrim -- removing this, cutflow is in line with Maria : Feb 14 2015
- //   //    if(!mu.auxdata< bool >("passOR")) continue; // dantrim -- in line with selectSignalObjects : Feb 14 2015
-        if(m_susyObj[m_eleIDDefault]->IsCosmicMuon(mu)) return false;
-
-     //   return(mu.auxdata<bool>("baseline") && mu.auxdata<bool>("passOR") && !m_susyObj[m_eleIDDefault]->IsCosmicMuon(mu));
+    bool pass_cosmic = true;
+    for(auto &i : m_baseMuons) {
+        if(muons->at(i)->auxdata< bool >("passOR") && muons->at(i)->auxdata< bool >("cosmic")) pass_cosmic = false;
     }
-     return true;
+    return pass_cosmic;
+
+
+//    for(auto it=muons->begin(), end=muons->end(); it!=end; ++it){
+//        const xAOD::Muon &mu = **it;
+//        if(!mu.auxdata< bool >("baseline")) continue; // dantrim -- removing this, cutflow is in line with Maria : Feb 14 2015
+//        if(!mu.auxdata< bool >("passOR")) continue; 
+//        if(m_susyObj[m_eleIDDefault]->IsCosmicMuon(mu)) return false;
+//
+//     //   return(mu.auxdata<bool>("baseline") && mu.auxdata<bool>("passOR") && !m_susyObj[m_eleIDDefault]->IsCosmicMuon(mu));
+//    }
+//     return true;
     //  return !IsCosmic(m_susyObj, xaodMuons(), m_baseMuons, 1., 0.2);
 }
 //----------------------------------------------------------

--- a/SusyCommon/TriggerMap.h
+++ b/SusyCommon/TriggerMap.h
@@ -9,19 +9,75 @@
 //
 // A little home for the triggers used in SusyNt
 // 
+//  TODO: dantrim Mar 17 2015 :
+//     (1) implement a function that takes arguments
+//          based (potentially) on metadata stored
+//          in the xAOD itself or from user input 
+//          and returns the appropriate vector
+//          of triggers
+//     (2)  implement a function that will be used
+//          when reading SusyNt that will read the
+//          trigger histogram to determine which
+//          triggers are stored and from bin-labels
+//          will then construct the appropriate
+//          map between the bits actually stored
+//          and the std::string of the trigger. User
+//          can then call triggers by name, regardless
+//          of how bits may have shifted.
+//
 // --------------------------------------------------
 
 
 namespace susy {
+//
+// a pseudo-random set of triggers used for testing the code
+// trigger naming found in :
+// https://twiki.cern.ch/twiki/bin/view/Atlas/TriggerMenuDC14Run2#Main_physics_triggers_AN2
+//
+    const std::vector<std::string> triggerNames = {
+        // electron triggers
+                "HLT_e24_medium1_iloose",
+                "HLT_e24_loose1",
+                "HLT_e28_tight1_iloose",
+                "HLT_e60_medium1",
+                "HLT_e60_loose1",
 
+        // muon triggers
+                "HLT_mu26_imedium",
+                "HLT_mu50",
+                "HLT_mu60_0eta105_msonly",
+                "HLT_2mu4",
+                "HLT_2mu6",
+                "HLT_2mu10",
+                "HLT_2mu14",
+                "HLT_3mu6",
+                
+        // photon triggers
+                "HLT_g120_loose1",
+                "HLT_g140_loose1",
+
+        // tau triggers
+                "HLT_e18_loose1_tau25_medium1_calo",
+                "HLT_e18_lhloose1_tau25_medium1_calo",
+                "HLT_mu14_tau25_medium1_calo",
+                "HLT_tau35_medium1_calo_tau25_medium1_calo",
+
+        // met triggers
+                "HLT_xe100"
+
+        };
+                
+                
+
+/*
     const std::vector<std::string> triggerNames = {
        // electron triggers 
-                "EF_e7_medium1",                       
-                "EF_e12Tvh_loose1",                    
-                "EF_e12Tvh_medium1",                   
-                "EF_e24vh_medium1",                    
-                "EF_e24vhi_medium1",                   
-                "EF_e24vh_medium1_e7_medium1",         
+               "_e7_medium1",                       
+                "_e12Tvh_loose1",                    
+                "_e12Tvh_medium1",                   
+                "_e24vh_medium1",                    
+                "_e24vhi_medium1",                   
+                "_e24vh_medium1_e7_medium1",      
 
         // muon triggers
                 "EF_mu8",                              
@@ -56,10 +112,10 @@ namespace susy {
         // MET triggers
                 "EF_2mu8_EFxe40wMu_tclcw",             
                 "EF_xe80_tclcw_loose", 
-                "EF_xe80T_tclcw_loose"
+                "EF_xe80T_tclcw_loose" 
             };
         
-
+*/
 
 }; // end namespace susy
 

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -50,6 +50,8 @@
 #include "TBits.h"
 #include "TrigConfxAOD/xAODConfigTool.h"
 #include "TrigDecisionTool/TrigDecisionTool.h"
+#include "xAODTrigger/TrigNavigation.h"
+#include "TrigConfHLTData/HLTTriggerElement.h"
 #include "xAODTrigEgamma/TrigElectron.h"
 #include "xAODTrigEgamma/TrigElectronContainer.h"
 
@@ -124,6 +126,7 @@ namespace susy {
     void          initPileupTool();
     void          initMuonTools(); 
     void          initTauTools(); 
+    void          initTrigger();
     
     // Systematic Methods
     void getSystematicList();
@@ -237,13 +240,13 @@ namespace susy {
     static std::string defauldGrlFile();
     bool initGrlTool();
     bool passGRL(const xAOD::EventInfo* eventinfo); ///< good run list
-    bool passTTCVeto(); ///< incomplete TTC event veto
+    bool passTTCVeto(const xAOD::EventInfo* eventinfo); ///< incomplete event 
     bool passTileErr(const xAOD::EventInfo* eventinfo); ///< Tile error
-    bool passLarErr(); ///< lar error
+    bool passLarErr(const xAOD::EventInfo* eventinfo); ///< lar error
 
     bool passLarHoleVeto(); ///< lar hole veto
     bool passTileHotSpot(); ///< tile hot spot
-    bool passBadJet(); ///< bad jet
+    bool passBadJet(ST::SystInfo sysInfo, SusyNtSys sys = NtSys::NOM); ///< bad jet
     bool passGoodVtx(); ///< good vertex
     bool passTileTrip(); ///< tile trip
     bool passBadMuon(ST::SystInfo sysInfo, SusyNtSys sys = NtSys::NOM); ///< bad muon veto


### PR DESCRIPTION
Updated code for ST 21 and Root 6.

Runs on top of `rcSetup Base,2.1.27`.

For sample input (-s command line option), if running over a derived AOD the sample name must contain "derived" (case INsensitive) in order to to re-calibrate jet energy densities (a la EventShapeTools). E.g. "mc14_derived".