### PR TITLE
Extend susy init

### DIFF
--- a/Root/SusyNtMaker.cxx
+++ b/Root/SusyNtMaker.cxx
@@ -510,6 +510,12 @@ void SusyNtMaker::storeMuon(const xAOD::Muon &in)
     out.isCosmic   = in.auxdata< char >("cosmic");
     out.isBadMuon  = m_susyObj[m_eleIDDefault]->IsBadMuon(in); // Uses default qoverpcut of 0.2
 
+    // muon quality
+    out.veryLoose = muIsOfType(in, muID::VeryLoose);
+    out.loose = muIsOfType(in, muID::Loose);
+    out.medium = muIsOfType(in, muID::Medium);
+    out.tight = muIsOfType(in, muID::Tight);
+
     bool all_available=true;
 
     // Isolation

--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -87,7 +87,10 @@ XaodAnalysis::XaodAnalysis() :
     m_elecSelLikelihoodTight_nod0(0),
 	m_pileupReweightingTool(0),
 	m_muonEfficiencySFTool(0),
-    m_muonSelectionTool(0),
+    m_muonSelectionToolVeryLoose(0),
+    m_muonSelectionToolLoose(0),
+    m_muonSelectionToolMedium(0),
+    m_muonSelectionToolTight(0),
 	m_tauTruthMatchingTool(0),
 	m_tauTruthTrackMatchingTool(0),
         //dantrim trig
@@ -194,7 +197,10 @@ void XaodAnalysis::Terminate()
 
     delete m_pileupReweightingTool;
     delete m_muonEfficiencySFTool;
-    delete m_muonSelectionTool;
+    delete m_muonSelectionToolVeryLoose;
+    delete m_muonSelectionToolLoose;
+    delete m_muonSelectionToolMedium;
+    delete m_muonSelectionToolTight;
     delete m_tauTruthMatchingTool;
     delete m_tauTruthTrackMatchingTool;
 
@@ -376,11 +382,25 @@ void XaodAnalysis::initMuonTools()
     CHECK( m_muonEfficiencySFTool->setProperty("DataPeriod","2012") );
     CHECK( m_muonEfficiencySFTool->initialize() );
 
-    m_muonSelectionTool = new CP::MuonSelectionTool("MuonSelectionTool_VeryLoose");
-    CHECK( m_muonSelectionTool->setProperty( "MaxEta", 2.5 ) );
-    CHECK( m_muonSelectionTool->setProperty( "MuQuality", int(xAOD::Muon::VeryLoose) ));// Warning: includes bad muons!
-    CHECK( m_muonSelectionTool->initialize() );
+    m_muonSelectionToolVeryLoose = new CP::MuonSelectionTool("MuonSelectionTool_VeryLoose");
+    CHECK( m_muonSelectionToolVeryLoose->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolVeryLoose->setProperty( "MuQuality", int(xAOD::Muon::VeryLoose) ));// Warning: includes bad muons!
+    CHECK( m_muonSelectionToolVeryLoose->initialize() );
 
+    m_muonSelectionToolLoose = new CP::MuonSelectionTool("MuonSelectionTool_Loose");
+    CHECK( m_muonSelectionToolLoose->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolLoose->setProperty( "MuQuality", int(xAOD::Muon::Loose) ));
+    CHECK( m_muonSelectionToolLoose->initialize() );
+    
+    m_muonSelectionToolMedium = new CP::MuonSelectionTool("MuonSelectionTool_Medium");
+    CHECK( m_muonSelectionToolMedium->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolMedium->setProperty( "MuQuality", int(xAOD::Muon::Medium) ));
+    CHECK( m_muonSelectionToolMedium->initialize() );
+
+    m_muonSelectionToolTight = new CP::MuonSelectionTool("MuonSelectionTool_Tight");
+    CHECK( m_muonSelectionToolTight->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolTight->setProperty( "MuQuality", int(xAOD::Muon::Tight) ));
+    CHECK( m_muonSelectionToolTight->initialize() );
 }
 //----------------------------------------------------------
 void XaodAnalysis::initTauTools()
@@ -740,7 +760,7 @@ void XaodAnalysis::selectBaselineObjects(SusyNtSys sys, ST::SystInfo sysInfo)
     for(const auto& mu : *muons){
         iMu++;
         if(mu->pt()* MeV2GeV > 3 && 
-           m_muonSelectionTool->accept(mu)) m_preMuons.push_back(iMu); //AT: Save VeryLoose pt>3 muon only
+           m_muonSelectionToolVeryLoose->accept(mu)) m_preMuons.push_back(iMu); //AT: Save VeryLoose pt>3 muon only
         //m_susyObj[m_eleIDDefault]->IsSignalMuon(*mu);
         m_susyObj[m_eleIDDefault]->IsSignalMuonExp(*mu, ST::SignalIsoExp::TightIso);
         m_susyObj[m_eleIDDefault]->IsCosmicMuon(*mu);
@@ -1099,6 +1119,17 @@ bool XaodAnalysis::eleIsOfType(const xAOD::Electron &in, eleID id)
     else if(id==eleID::TightLLH_nod0  && m_elecSelLikelihoodTight_nod0->accept(in))  return true;
     return false;
 }
+/*--------------------------------------------------------------------------------*/
+// Return muon type
+/*--------------------------------------------------------------------------------*/
+bool XaodAnalysis::muIsOfType(const xAOD::Muon &in, muID id)
+{
+    if     (id==muID::VeryLoose && m_muonSelectionToolVeryLoose->accept(in))  return true;
+    else if(id==muID::Loose     && m_muonSelectionToolLoose    ->accept(in))  return true;
+    else if(id==muID::Medium    && m_muonSelectionToolMedium   ->accept(in))  return true;
+    else if(id==muID::Tight     && m_muonSelectionToolTight    ->accept(in))  return true;
+    return false;
+} 
 /*--------------------------------------------------------------------------------*/
 // Get triggers
 /*--------------------------------------------------------------------------------*/

--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -261,6 +261,27 @@ XaodAnalysis& XaodAnalysis::initSusyTools()
                 m_susyObj[i]->getPropertyMgr()->getProperty(x.first, foo);
                 cout << " Property << " << x.first << ": " << foo << endl;
             }
+            else if(x.second->typeName()=="int"){
+                int foo;
+                m_susyObj[i]->getPropertyMgr()->getProperty(x.first, foo);
+                cout << " Property << " << x.first << ": " << foo << endl;
+            }
+            else if(x.second->typeName()=="float"){
+                float foo;
+                m_susyObj[i]->getPropertyMgr()->getProperty(x.first, foo);
+                cout << " Property << " << x.first << ": " << foo << endl;
+            }
+            else if(x.second->typeName()=="double"){
+                double foo;
+                m_susyObj[i]->getPropertyMgr()->getProperty(x.first, foo);
+                cout << " Property << " << x.first << ": " << foo << endl;
+            }
+            else if(x.second->typeName()=="bool"){
+                bool foo;
+                m_susyObj[i]->getPropertyMgr()->getProperty(x.first, foo);
+                string value = foo ? "True" : "False";
+                cout << " Property << " << x.first << ": " << value << endl;
+            }
         }
         
         CHECK( m_susyObj[i]->SUSYToolsInit() );

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -118,6 +118,22 @@ namespace Susy {
     ,"eleIDInvalid"
   };
 
+  enum muID{
+    VeryLoose=0
+    ,Loose
+    ,Medium
+    ,Tight
+    ,muIDInvalid
+  };
+
+  const std::string muIDNames[] = {
+    "VeryLoose"
+    ,"Loose"
+    ,"Medium"
+    ,"Tight"
+    ,"muIDInvalid"
+  };
+
   ///  a class for performing object selections and event cleaning on xaod
   class XaodAnalysis : public TSelector
   {
@@ -325,6 +341,7 @@ namespace Susy {
     bool matchTruthJet(int iJet); ///< Match a reco jet to a truth jet
 
     bool eleIsOfType(const xAOD::Electron &in, eleID id=eleID::LooseLLH);
+    bool muIsOfType(const xAOD::Muon &in, muID id=muID::Medium);
 
 
     // Running conditions
@@ -611,7 +628,10 @@ namespace Susy {
     CP::PileupReweightingTool           *m_pileupReweightingTool;
 
     CP::MuonEfficiencyScaleFactors      *m_muonEfficiencySFTool; 
-    CP::MuonSelectionTool               *m_muonSelectionTool;
+    CP::MuonSelectionTool               *m_muonSelectionToolVeryLoose;
+    CP::MuonSelectionTool               *m_muonSelectionToolLoose;
+    CP::MuonSelectionTool               *m_muonSelectionToolMedium;
+    CP::MuonSelectionTool               *m_muonSelectionToolTight;
 
     //Tau truth matchong tools
     TauAnalysisTools::TauTruthMatchingTool       *m_tauTruthMatchingTool;


### PR DESCRIPTION
Extend the value types for the print out of the SUSYTools object properties
- All additional properties have value "unknown" and will most likely not be set by us, but kept to SUSYTools defaults