### PR TITLE
Muon quality flags

### DIFF
--- a/Root/SusyNtMaker.cxx
+++ b/Root/SusyNtMaker.cxx
@@ -511,10 +511,10 @@ void SusyNtMaker::storeMuon(const xAOD::Muon &in)
     out.isBadMuon  = m_susyObj[m_eleIDDefault]->IsBadMuon(in); // Uses default qoverpcut of 0.2
 
     // muon quality
-    out.veryLoose = muIsOfType(in, muID::VeryLoose);
-    out.loose = muIsOfType(in, muID::Loose);
-    out.medium = muIsOfType(in, muID::Medium);
-    out.tight = muIsOfType(in, muID::Tight);
+    out.veryLoose = muIsOfType(in, MuonId::VeryLoose);
+    out.loose = muIsOfType(in, MuonId::Loose);
+    out.medium = muIsOfType(in, MuonId::Medium);
+    out.tight = muIsOfType(in, MuonId::Tight);
 
     bool all_available=true;
 

--- a/Root/SusyNtMaker.cxx
+++ b/Root/SusyNtMaker.cxx
@@ -510,6 +510,12 @@ void SusyNtMaker::storeMuon(const xAOD::Muon &in)
     out.isCosmic   = in.auxdata< char >("cosmic");
     out.isBadMuon  = m_susyObj[m_eleIDDefault]->IsBadMuon(in); // Uses default qoverpcut of 0.2
 
+    // muon quality
+    out.veryLoose = muIsOfType(in, muID::VeryLoose);
+    out.loose = muIsOfType(in, muID::Loose);
+    out.medium = muIsOfType(in, muID::Medium);
+    out.tight = muIsOfType(in, muID::Tight);
+
     bool all_available=true;
 
     // Isolation

--- a/Root/SusyNtMaker.cxx
+++ b/Root/SusyNtMaker.cxx
@@ -378,13 +378,13 @@ void SusyNtMaker::storeElectron(const xAOD::Electron &in)
     out.q   = in.charge();
     bool all_available=true;
     
-    out.veryLooseLLH = eleIsOfType(in, eleID::VeryLooseLLH);
-    out.looseLLH = eleIsOfType(in, eleID::LooseLLH);
-    out.mediumLLH = eleIsOfType(in, eleID::MediumLLH);
-    out.tightLLH = eleIsOfType(in, eleID::TightLLH);
-    out.looseLLH_nod0 = eleIsOfType(in, eleID::LooseLLH_nod0);
-    out.mediumLLH_nod0 = eleIsOfType(in, eleID::MediumLLH_nod0);
-    out.tightLLH_nod0 = eleIsOfType(in, eleID::TightLLH_nod0);
+    out.veryLooseLLH = eleIsOfType(in, ElectronId::VeryLooseLLH);
+    out.looseLLH = eleIsOfType(in, ElectronId::LooseLLH);
+    out.mediumLLH = eleIsOfType(in, ElectronId::MediumLLH);
+    out.tightLLH = eleIsOfType(in, ElectronId::TightLLH);
+    out.looseLLH_nod0 = eleIsOfType(in, ElectronId::LooseLLH_nod0);
+    out.mediumLLH_nod0 = eleIsOfType(in, ElectronId::MediumLLH_nod0);
+    out.tightLLH_nod0 = eleIsOfType(in, ElectronId::TightLLH_nod0);
 
     //Isolations
     //AT: Will become obsolete in run-2
@@ -418,12 +418,12 @@ void SusyNtMaker::storeElectron(const xAOD::Electron &in)
         bool recoSF=true;
         bool idSF=true;
         bool trigSF=false;
-        if(eleIsOfType(in, eleID::TightLLH))           
-            out.effSF = m_susyObj[eleID::TightLLH]->GetSignalElecSF(in, recoSF, idSF, trigSF);
-        else if(eleIsOfType(in, eleID::MediumLLH))
-            out.effSF = m_susyObj[eleID::MediumLLH]->GetSignalElecSF(in, recoSF, idSF, trigSF);	 
-        else if(eleIsOfType(in, eleID::LooseLLH))
-            out.effSF = m_susyObj[eleID::LooseLLH]->GetSignalElecSF(in, recoSF, idSF, trigSF);
+        if(eleIsOfType(in, ElectronId::TightLLH))
+            out.effSF = m_susyObj[ElectronId::TightLLH]->GetSignalElecSF(in, recoSF, idSF, trigSF);
+        else if(eleIsOfType(in, ElectronId::MediumLLH))
+            out.effSF = m_susyObj[ElectronId::MediumLLH]->GetSignalElecSF(in, recoSF, idSF, trigSF);
+        else if(eleIsOfType(in, ElectronId::LooseLLH))
+            out.effSF = m_susyObj[ElectronId::LooseLLH]->GetSignalElecSF(in, recoSF, idSF, trigSF);
 
       
        /* 
@@ -442,7 +442,7 @@ void SusyNtMaker::storeElectron(const xAOD::Electron &in)
         int matchedPdgId = truthEle ? truthEle->pdgId() : -999;
         out.truthType  = isFakeLepton(out.mcOrigin, out.mcType, matchedPdgId); 
         //AT: 05-02-15: Issue accessing Aux of trackParticle in truthElectronCharge. Info not in derived AOD ?
-        //if(eleIsOfType(in, eleID::LooseLLH))
+        //if(eleIsOfType(in, ElectronId::LooseLLH))
         //    out.isChargeFlip  = m_isMC ? isChargeFlip(in.charge(),truthElectronCharge(in)) : false;
     }
 

--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -1123,12 +1123,12 @@ bool XaodAnalysis::eleIsOfType(const xAOD::Electron &in, ElectronId id)
 /*--------------------------------------------------------------------------------*/
 // Return muon type
 /*--------------------------------------------------------------------------------*/
-bool XaodAnalysis::muIsOfType(const xAOD::Muon &in, muID id)
+bool XaodAnalysis::muIsOfType(const xAOD::Muon &in, MuonId id)
 {
-    if     (id==muID::VeryLoose && m_muonSelectionToolVeryLoose->accept(in))  return true;
-    else if(id==muID::Loose     && m_muonSelectionToolLoose    ->accept(in))  return true;
-    else if(id==muID::Medium    && m_muonSelectionToolMedium   ->accept(in))  return true;
-    else if(id==muID::Tight     && m_muonSelectionToolTight    ->accept(in))  return true;
+    if     (id==MuonId::VeryLoose && m_muonSelectionToolVeryLoose->accept(in))  return true;
+    else if(id==MuonId::Loose     && m_muonSelectionToolLoose    ->accept(in))  return true;
+    else if(id==MuonId::Medium    && m_muonSelectionToolMedium   ->accept(in))  return true;
+    else if(id==MuonId::Tight     && m_muonSelectionToolTight    ->accept(in))  return true;
     return false;
 } 
 /*--------------------------------------------------------------------------------*/

--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -219,7 +219,8 @@ void XaodAnalysis::Terminate()
 XaodAnalysis& XaodAnalysis::initSusyTools()
 {
     for(int i=TightLLH; i<=LooseLLH; i++){
-        string name = "SUSYObjDef_xAOD_" + eleIDNames[i];
+        string electronIdName = ElectronId2str(static_cast<ElectronId>(i));
+        string name = "SUSYObjDef_xAOD_" + electronIdName;
         m_susyObj[i] = new ST::SUSYObjDef_xAOD(name);
         cout << "------------------------------------------------------------" << endl;
         cout << "XaodAnalysis::initSusyTools: " << name <<endl;
@@ -227,7 +228,7 @@ XaodAnalysis& XaodAnalysis::initSusyTools()
 
         m_susyObj[i]->msg().setLevel(m_dbg ? MSG::DEBUG : MSG::WARNING);
         //m_susyObj[i]->msg().setLevel(m_dbg ? MSG::VERBOSE : MSG::WARNING);
-        m_susyObj[i]->setProperty("EleId", eleIDNames[i]);
+        m_susyObj[i]->setProperty("EleId", electronIdName);
         int datasource = !m_isMC ? ST::Data : (m_isAF2 ? ST::AtlfastII : ST::FullSim);
         m_susyObj[i]->setProperty("DataSource",datasource);
 
@@ -1107,16 +1108,16 @@ bool XaodAnalysis::matchTruthJet(int iJet)
 /*--------------------------------------------------------------------------------*/
 // Return electron type
 /*--------------------------------------------------------------------------------*/
-bool XaodAnalysis::eleIsOfType(const xAOD::Electron &in, eleID id)
+bool XaodAnalysis::eleIsOfType(const xAOD::Electron &in, ElectronId id)
 {
-    if     (id==eleID::VeryLooseLLH  && m_elecSelLikelihoodVeryLoose->accept(in))  return true;
-    else if(id==eleID::LooseLLH  && m_elecSelLikelihoodLoose->accept(in))  return true;
-    else if(id==eleID::MediumLLH && m_elecSelLikelihoodMedium->accept(in)) return true;
-    else if(id==eleID::TightLLH  && m_elecSelLikelihoodTight->accept(in))  return true;
+    if     (id==ElectronId::VeryLooseLLH  && m_elecSelLikelihoodVeryLoose->accept(in))  return true;
+    else if(id==ElectronId::LooseLLH  && m_elecSelLikelihoodLoose->accept(in))  return true;
+    else if(id==ElectronId::MediumLLH && m_elecSelLikelihoodMedium->accept(in)) return true;
+    else if(id==ElectronId::TightLLH  && m_elecSelLikelihoodTight->accept(in))  return true;
 
-    else if(id==eleID::LooseLLH_nod0  && m_elecSelLikelihoodLoose_nod0->accept(in))  return true;
-    else if(id==eleID::MediumLLH_nod0 && m_elecSelLikelihoodMedium_nod0->accept(in)) return true;
-    else if(id==eleID::TightLLH_nod0  && m_elecSelLikelihoodTight_nod0->accept(in))  return true;
+    else if(id==ElectronId::LooseLLH_nod0  && m_elecSelLikelihoodLoose_nod0->accept(in))  return true;
+    else if(id==ElectronId::MediumLLH_nod0 && m_elecSelLikelihoodMedium_nod0->accept(in)) return true;
+    else if(id==ElectronId::TightLLH_nod0  && m_elecSelLikelihoodTight_nod0->accept(in))  return true;
     return false;
 }
 /*--------------------------------------------------------------------------------*/

--- a/Root/XaodAnalysis.cxx
+++ b/Root/XaodAnalysis.cxx
@@ -87,7 +87,10 @@ XaodAnalysis::XaodAnalysis() :
     m_elecSelLikelihoodTight_nod0(0),
 	m_pileupReweightingTool(0),
 	m_muonEfficiencySFTool(0),
-    m_muonSelectionTool(0),
+    m_muonSelectionToolVeryLoose(0),
+    m_muonSelectionToolLoose(0),
+    m_muonSelectionToolMedium(0),
+    m_muonSelectionToolTight(0),
 	m_tauTruthMatchingTool(0),
 	m_tauTruthTrackMatchingTool(0),
         //dantrim trig
@@ -194,7 +197,10 @@ void XaodAnalysis::Terminate()
 
     delete m_pileupReweightingTool;
     delete m_muonEfficiencySFTool;
-    delete m_muonSelectionTool;
+    delete m_muonSelectionToolVeryLoose;
+    delete m_muonSelectionToolLoose;
+    delete m_muonSelectionToolMedium;
+    delete m_muonSelectionToolTight;
     delete m_tauTruthMatchingTool;
     delete m_tauTruthTrackMatchingTool;
 
@@ -376,11 +382,25 @@ void XaodAnalysis::initMuonTools()
     CHECK( m_muonEfficiencySFTool->setProperty("DataPeriod","2012") );
     CHECK( m_muonEfficiencySFTool->initialize() );
 
-    m_muonSelectionTool = new CP::MuonSelectionTool("MuonSelectionTool_VeryLoose");
-    CHECK( m_muonSelectionTool->setProperty( "MaxEta", 2.5 ) );
-    CHECK( m_muonSelectionTool->setProperty( "MuQuality", int(xAOD::Muon::VeryLoose) ));// Warning: includes bad muons!
-    CHECK( m_muonSelectionTool->initialize() );
+    m_muonSelectionToolVeryLoose = new CP::MuonSelectionTool("MuonSelectionTool_VeryLoose");
+    CHECK( m_muonSelectionToolVeryLoose->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolVeryLoose->setProperty( "MuQuality", int(xAOD::Muon::VeryLoose) ));// Warning: includes bad muons!
+    CHECK( m_muonSelectionToolVeryLoose->initialize() );
 
+    m_muonSelectionToolLoose = new CP::MuonSelectionTool("MuonSelectionTool_Loose");
+    CHECK( m_muonSelectionToolLoose->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolLoose->setProperty( "MuQuality", int(xAOD::Muon::Loose) ));
+    CHECK( m_muonSelectionToolLoose->initialize() );
+    
+    m_muonSelectionToolMedium = new CP::MuonSelectionTool("MuonSelectionTool_Medium");
+    CHECK( m_muonSelectionToolMedium->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolMedium->setProperty( "MuQuality", int(xAOD::Muon::Medium) ));
+    CHECK( m_muonSelectionToolMedium->initialize() );
+
+    m_muonSelectionToolTight = new CP::MuonSelectionTool("MuonSelectionTool_Tight");
+    CHECK( m_muonSelectionToolTight->setProperty( "MaxEta", 2.5 ) );
+    CHECK( m_muonSelectionToolTight->setProperty( "MuQuality", int(xAOD::Muon::Tight) ));
+    CHECK( m_muonSelectionToolTight->initialize() );
 }
 //----------------------------------------------------------
 void XaodAnalysis::initTauTools()
@@ -740,7 +760,7 @@ void XaodAnalysis::selectBaselineObjects(SusyNtSys sys, ST::SystInfo sysInfo)
     for(const auto& mu : *muons){
         iMu++;
         if(mu->pt()* MeV2GeV > 3 && 
-           m_muonSelectionTool->accept(mu)) m_preMuons.push_back(iMu); //AT: Save VeryLoose pt>3 muon only
+           m_muonSelectionToolVeryLoose->accept(mu)) m_preMuons.push_back(iMu); //AT: Save VeryLoose pt>3 muon only
         //m_susyObj[m_eleIDDefault]->IsSignalMuon(*mu);
         m_susyObj[m_eleIDDefault]->IsSignalMuonExp(*mu, ST::SignalIsoExp::TightIso);
         m_susyObj[m_eleIDDefault]->IsCosmicMuon(*mu);
@@ -1099,6 +1119,17 @@ bool XaodAnalysis::eleIsOfType(const xAOD::Electron &in, eleID id)
     else if(id==eleID::TightLLH_nod0  && m_elecSelLikelihoodTight_nod0->accept(in))  return true;
     return false;
 }
+/*--------------------------------------------------------------------------------*/
+// Return muon type
+/*--------------------------------------------------------------------------------*/
+bool XaodAnalysis::muIsOfType(const xAOD::Muon &in, muID id)
+{
+    if     (id==muID::VeryLoose && m_muonSelectionToolVeryLoose->accept(in))  return true;
+    else if(id==muID::Loose     && m_muonSelectionToolLoose    ->accept(in))  return true;
+    else if(id==muID::Medium    && m_muonSelectionToolMedium   ->accept(in))  return true;
+    else if(id==muID::Tight     && m_muonSelectionToolTight    ->accept(in))  return true;
+    return false;
+} 
 /*--------------------------------------------------------------------------------*/
 // Get triggers
 /*--------------------------------------------------------------------------------*/

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -118,6 +118,22 @@ namespace Susy {
     ,"eleIDInvalid"
   };
 
+  enum muID{
+    VeryLoose=0
+    ,Loose
+    ,Medium
+    ,Tight
+    ,muIDInvalid
+  };
+
+  const std::string muIDNames[] = {
+    "VeryLoose"
+    ,"Loose"
+    ,"Medium"
+    ,"Tight"
+    ,"muIDInvalid"
+  };
+
   ///  a class for performing object selections and event cleaning on xaod
   class XaodAnalysis : public TSelector
   {
@@ -325,6 +341,7 @@ namespace Susy {
     bool matchTruthJet(int iJet); ///< Match a reco jet to a truth jet
 
     bool eleIsOfType(const xAOD::Electron &in, eleID id=eleID::LooseLLH);
+    bool muIsOfType(const xAOD::Muon &in, muID id=muID::Medium);
 
 
     // Running conditions
@@ -611,7 +628,10 @@ namespace Susy {
     CP::PileupReweightingTool           *m_pileupReweightingTool;
 
     CP::MuonEfficiencyScaleFactors      *m_muonEfficiencySFTool; 
-    CP::MuonSelectionTool               *m_muonSelectionTool;
+    CP::MuonSelectionTool               *m_muonSelectionToolVeryLoose;
+    CP::MuonSelectionTool               *m_muonSelectionToolLoose;
+    CP::MuonSelectionTool               *m_muonSelectionToolMedium;
+    CP::MuonSelectionTool               *m_muonSelectionToolTight;
 
     //Tau truth matchong tools
     TauAnalysisTools::TauTruthMatchingTool       *m_tauTruthMatchingTool;

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -12,9 +12,11 @@
 #include "SUSYTools/SUSYObjDef_xAOD.h"
 #include "LeptonTruthTools/RecoTauMatch.h"
 
+#include "SusyNtuple/ElectronId.h"
 #include "SusyCommon/LeptonInfo.h"
-#include "SusyNtuple/SusyNt.h"
+#include "SusyNtuple/MuonId.h"
 #include "SusyNtuple/SusyDefs.h"
+#include "SusyNtuple/SusyNt.h"
 #include "SusyNtuple/SusyNtSys.h"
 
 //xAOD
@@ -95,44 +97,6 @@ class TDirectory;
 namespace Susy {
   
   const double MeV2GeV=1.0e-3;
-
-  enum eleID{
-    TightLLH=0
-    ,MediumLLH
-    ,LooseLLH
-    ,VeryLooseLLH
-    ,TightLLH_nod0
-    ,MediumLLH_nod0
-    ,LooseLLH_nod0    
-    ,eleIDInvalid
-  };
-  
-  const std::string eleIDNames[] = {
-    "TightLLH"
-    ,"MediumLLH"
-    ,"LooseLLH"
-    ,"VeryLooseLLH"
-    ,"TightLLH_nod0"
-    ,"MediumLLH_nod0"
-    ,"LooseLLH_nod0"
-    ,"eleIDInvalid"
-  };
-
-  enum muID{
-    VeryLoose=0
-    ,Loose
-    ,Medium
-    ,Tight
-    ,muIDInvalid
-  };
-
-  const std::string muIDNames[] = {
-    "VeryLoose"
-    ,"Loose"
-    ,"Medium"
-    ,"Tight"
-    ,"muIDInvalid"
-  };
 
   ///  a class for performing object selections and event cleaning on xaod
   class XaodAnalysis : public TSelector

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -304,7 +304,7 @@ namespace Susy {
     uint getNumGoodVtx(); ///< Count number of good vertices
     bool matchTruthJet(int iJet); ///< Match a reco jet to a truth jet
 
-    bool eleIsOfType(const xAOD::Electron &in, eleID id);
+    bool eleIsOfType(const xAOD::Electron &in, ElectronId id);
     bool muIsOfType(const xAOD::Muon &in, muID id);
 
 
@@ -495,8 +495,8 @@ namespace Susy {
     xAOD::TEvent m_event;
     xAOD::TStore m_store;
 
-    ST::SUSYObjDef_xAOD* m_susyObj[eleID::eleIDInvalid];      // SUSY object definitions
-    eleID m_eleIDDefault;
+    ST::SUSYObjDef_xAOD* m_susyObj[ElectronId::ElectronIdInvalid];      // SUSY object definitions
+    ElectronId m_eleIDDefault;
 
     std::vector<CP::SystematicSet> sysList;  //CP Systematic list
     std::vector<ST::SystInfo> systInfoList;  //SystInfo is a SUSYTools simplify version struct

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -340,8 +340,8 @@ namespace Susy {
     uint getNumGoodVtx(); ///< Count number of good vertices
     bool matchTruthJet(int iJet); ///< Match a reco jet to a truth jet
 
-    bool eleIsOfType(const xAOD::Electron &in, eleID id=eleID::LooseLLH);
-    bool muIsOfType(const xAOD::Muon &in, muID id=muID::Medium);
+    bool eleIsOfType(const xAOD::Electron &in, eleID id);
+    bool muIsOfType(const xAOD::Muon &in, muID id);
 
 
     // Running conditions

--- a/SusyCommon/XaodAnalysis.h
+++ b/SusyCommon/XaodAnalysis.h
@@ -305,7 +305,7 @@ namespace Susy {
     bool matchTruthJet(int iJet); ///< Match a reco jet to a truth jet
 
     bool eleIsOfType(const xAOD::Electron &in, ElectronId id);
-    bool muIsOfType(const xAOD::Muon &in, muID id);
+    bool muIsOfType(const xAOD::Muon &in, MuonId id);
 
 
     // Running conditions


### PR DESCRIPTION
Goes with gerbaudo/SusyNtuple#61
Stores the muon quality flags.
Need to use the same enums as the one used in `ElectronSelector`
and `MuonSelector`, so it required several changes here and there.